### PR TITLE
Move imports of os and psutil

### DIFF
--- a/awsr
+++ b/awsr
@@ -4,8 +4,6 @@
 import os
 import sys
 import tempfile
-import psutil
-import subprocess
 
 rd = tempfile.gettempdir() + "/awsr_rd"
 wr = tempfile.gettempdir() + "/awsr_wr"
@@ -94,6 +92,8 @@ def main():
 		return
 
 	# fork if awsr daemon is not already running
+	import psutil
+	import subprocess
 	ps = psutil.process_iter(attrs=["cmdline"])
 	procs = 0
 	for p in ps:


### PR DESCRIPTION
This way users do not need to install psutil if they explicitly invoke
the client or server.  It also reduces the startup time of the client.