### PR TITLE
Fix up README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-= WTF is this?
+= aws-cli-repl
 
 This is a https://en.m.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop[REPL (read-eval-print loop)] version of the https://github.com/aws/aws-cli[`aws-cli`]; one that can run multiple commands via a single AWS CLI session.
 
@@ -17,14 +17,14 @@ In the "regular" approach, each newly created API client has to establish a fres
 
 Under the standard AWS CLI, this happens for every invocation (command); as each command spawns a new process, which does all this initialization and connectivity stuff, but then discards everything as the process dies at command completion.
 
-Additionally there's always the overhead of process spawning, loading of binaries, configs and https://github.com/boto/botocore/tree/master/botocore/data/[API definitions], dynamic https://github.com/boto/botocore/blob/master/botocore/client.py[generation] of `boto` client classes, initialization of parsers, command maps, https://github.com/boto/botocore/blob/master/botocore/hooks.py[event handlers], https://github.com/aws/aws-cli/blob/master/awscli/customizations/__init__.py[customizations] and god-knows-what-else stuff. While this overhead is quite acceptable for a few invocations, it can add up when you're batching hundreds of consecutive invocations.
+Additionally there's always the overhead of process spawning, loading of binaries, configs and https://github.com/boto/botocore/tree/master/botocore/data/[API definitions], dynamic https://github.com/boto/botocore/blob/master/botocore/client.py[generation] of `boto` client classes, initialization of parsers, command maps, https://github.com/boto/botocore/blob/master/botocore/hooks.py[event handlers], https://github.com/aws/aws-cli/blob/master/awscli/customizations/$$__init__.py$$[customizations] and god-knows-what-else stuff. While this overhead is quite acceptable for a few invocations, it can add up when you're batching hundreds of consecutive invocations.
 
 
-= So, what's the magic behind your `aws-cli-repl`?
+== So, what's the magic behind your `aws-cli-repl`?
 
 This REPL breaks the CLI into two components: a _client_ and a _daemon_ (just a background process, to be frank).
 
-== The client
+=== The client
 
 It simply:
 
@@ -33,23 +33,23 @@ It simply:
 * reads the result from another named pipe and
 * shows it to the user.
 
-== The daemon
+=== The daemon
 
 This has the fun stuff. At launch, it:
 
 * initializes an https://github.com/aws/aws-cli/blob/master/awscli/clidriver.py[`awscli.CLIDriver`] instance
-* patches `__init__` and `invoke` on https://github.com/aws/aws-cli/blob/master/awscli/clidriver.py[`awscli.CLIOperationCaller`], to cache the `client` objects created during `invoke`
+* patches `$$__init__$$` and `invoke` on https://github.com/aws/aws-cli/blob/master/awscli/clidriver.py[`awscli.CLIOperationCaller`], to cache the `client` objects created during `invoke`
 
 Then it starts to loop:
 
 * point `sys.stdin` to the client's output pipe, and `sys.stdout` to its input pipe,
 * read user commands (piped by the client),
-* feed them to `CLIDriver`'s `main` method, causing a CLI invocation, and
+* feed them to ``CLIDriver``'s `main` method, causing a CLI invocation, and
 * the CLI writes the output to `sys.stdout`, effectively piping it back to the client
 
-This way, the `CLIDriver` instance (and hence the clients cached by `CLIOperationCaller`s) are kept alive throughout the life of the daemon, no matter how many times the client gets invoked; yielding all the benefits that we discussed before.
+This way, the `CLIDriver` instance (and hence the clients cached by ``CLIOperationCaller``s) are kept alive throughout the life of the daemon, no matter how many times the client gets invoked; yielding all the benefits that we discussed before.
 
-== How does the daemon launch?
+=== How does the daemon launch?
 
 During its first invocation, the REPL checks for the existence of the daemon in the system's https://stackoverflow.com/questions/46979567/find-processes-by-command-in-python[process list].
 If it doesn't see one, it spawns a copy of itself, flagging it to run as the daemon - and continues its own journey as client, calling the new daemon via pipes as usual.
@@ -57,15 +57,15 @@ If it doesn't see one, it spawns a copy of itself, flagging it to run as the dae
 So it effectively initializes itself during the first run, and remains alive as long as possible; consuming little resources (as it's only waiting to read from the named pipe). If it somehow gets killed, the next REPL invocation will spawn a new daemon.
 
 
-= Installation
-
-== Prerequisites
-
-* Python 2.7 (3.x _might_ work, with some tweaks)
-* https://github.com/aws/aws-cli[`awscli`]
-* https://github.com/giampaolo/psutil[`psutil`]
-
 == Installation
+
+=== Prerequisites
+
+* Python 2.7 or 3.x
+* https://github.com/aws/aws-cli[`awscli`]
+* https://github.com/giampaolo/psutil[`psutil`] (optional)
+
+=== Installation
 
 Assuming the `awscli` module is resolvable by Python (e.g. via `PYTHONPATH`), simply
 
@@ -83,7 +83,7 @@ awsr ec2 describe-instances
 Watch-mode commands that produce progressive output (like `ec2 wait instance-running`) may not work as expected (since the client does not receive output until the command execution completes).
 
 
-= What kind of improvement am I looking at?
+== What kind of improvement am I looking at?
 
 I don't have concrete figures (yet), but my first try with a batch deletion of https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html[CloudWatch log groups] was quite impressive.
 
@@ -97,12 +97,12 @@ Deleting around 150 log groups via `awsr`:
 
 * took around 2 minutes and
 * consumed less than 1MB of data,
-* with one initial DNS lookup, SSL handshakes limited to once per minute (could probably be further improved by tuning `boto`'s connectivity options).
+* with one initial DNS lookup, SSL handshakes limited to once per minute (could probably be further improved by tuning ``boto``'s connectivity options).
 
 Results may vary across AWS services and usage patterns, but I'm quite satisfied with what I've seen so far.
 
 
-= What's the catch?
+== What's the catch?
 
 There's a lot:
 
@@ -110,16 +110,21 @@ There's a lot:
 * Global parameters are not re-initialized for subsequent client calls. If you invoked it for `us-east-1` under profile `golum`, all subsequent commands executed by that daemon will run against the same region and profile. This can probably be avoided by invalidating or expanding the client cache; I'll need to look into that further.
 * `sys.stderr` is not redirected from daemon to client, so any errors (say, a S3 403 Forbidden) on the daemon will not be visible at the client - unless they're running in the same terminal window.
 * Some extensions like S3 don't seem to benefit from the caching - even when invoked against the same bucket. It needs further investigation.
-* Only supports Python 2.7 (although I believe only a few tweaks would suffice to port it to 3.x).
 
 
-= Disclaimer
+== Disclaimer
 
 No need to drag on with formalities; _you're on your own_.
 
 I will continue to experiment with `awsr` and attempt to fix issues as and when required (and possible), but it is still considered highly experimental and unstable :)
 
 
-= Contributing
+== Contributing
 
 Feel free to report any issues that you encounter while using the tool; or, better still, submit a PR (after all, there's not even a hundred lines of code here so far :))
+
+== License
+
+Copyright (C) 2018-2021 Janaka Bandara
+
+Licensed under the Apache License, Version 2.0


### PR DESCRIPTION
* Use only a single top-level header
* Fix `__init__` links
* Fix monospace possessives
* Mention Python 3.x compatibility
* Add license

References #4.